### PR TITLE
Add log suffix to syslog config and file watcher

### DIFF
--- a/.concourse.yml
+++ b/.concourse.yml
@@ -4,7 +4,7 @@ resources:
   type: git
   source:
     branch: master
-    uri: https://github.com/cloudfoundry/blackbox.git
+    uri: https://github.com/CrunchyData/blackbox.git
 
 jobs:
 - name: tests
@@ -33,7 +33,7 @@ jobs:
 
             workspace=$PWD
             mkdir -p $GOPATH/src/github.com/cloudfoundry
-            ln -s $workspace/blackbox $GOPATH/src/github.com/cloudfoundry/blackbox
+            ln -s $workspace/blackbox $GOPATH/src/github.com/CrunchyData/blackbox
             go get github.com/onsi/ginkgo
             go get github.com/hpcloud/tail
             go get github.com/onsi/gomega

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently the priority and facility are hardcoded to `INFO` and `user`.
 ## Installation
 
 ```
-go get -u github.com/cloudfoundry/blackbox/cmd/blackbox
+go get -u github.com/CrunchyData/blackbox/cmd/blackbox
 ```
 
 [CI]: https://syslog.ci.cf-app.com

--- a/cmd/blackbox/main.go
+++ b/cmd/blackbox/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tedsuo/ifrit/grouper"
 	"github.com/tedsuo/ifrit/sigmon"
 
-	"github.com/cloudfoundry/blackbox"
+	"github.com/CrunchyData/blackbox"
 )
 
 var configPath = flag.String(
@@ -36,7 +36,7 @@ func main() {
 	running := ifrit.Invoke(sigmon.New(group))
 
 	go func() {
-		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData)
+		fileWatcher := blackbox.NewFileWatcher(logger, config.Syslog.SourceDir, config.Syslog.LogSuffix, group.Client(), config.Syslog.Destination, config.Hostname, config.StructuredData)
 		fileWatcher.Watch()
 	}()
 

--- a/config.go
+++ b/config.go
@@ -4,13 +4,14 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/cloudfoundry/blackbox/syslog"
+	"github.com/CrunchyData/blackbox/syslog"
 	"gopkg.in/yaml.v2"
 )
 
 type SyslogConfig struct {
 	Destination syslog.Drain `yaml:"destination"`
 	SourceDir   string       `yaml:"source_dir"`
+	LogSuffix   string       `yaml:"log_suffix"`
 }
 
 type Config struct {

--- a/file_watcher.go
+++ b/file_watcher.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudfoundry/blackbox/syslog"
+	"github.com/CrunchyData/blackbox/syslog"
 	"github.com/tedsuo/ifrit/grouper"
 )
 
@@ -18,6 +18,7 @@ type fileWatcher struct {
 	logger *log.Logger
 
 	sourceDir          string
+	logSuffix          string
 	dynamicGroupClient grouper.DynamicClient
 	hostname           string
 	structuredData     string
@@ -28,6 +29,7 @@ type fileWatcher struct {
 func NewFileWatcher(
 	logger *log.Logger,
 	sourceDir string,
+	logSuffix string,
 	dynamicGroupClient grouper.DynamicClient,
 	drain syslog.Drain,
 	hostname string,
@@ -36,6 +38,7 @@ func NewFileWatcher(
 	return &fileWatcher{
 		logger:             logger,
 		sourceDir:          sourceDir,
+		logSuffix:          logSuffix,
 		dynamicGroupClient: dynamicGroupClient,
 		drain:              drain,
 		hostname:           hostname,
@@ -73,7 +76,7 @@ func (f *fileWatcher) Watch() {
 
 func (f *fileWatcher) findLogsToWatch(tag string, filePath string, file os.FileInfo) {
 	if !file.IsDir() {
-		if strings.HasSuffix(file.Name(), ".log") {
+		if strings.HasSuffix(file.Name(), f.logSuffix) {
 			if _, found := f.dynamicGroupClient.Get(filePath); !found {
 				f.dynamicGroupClient.Inserter() <- f.memberForFile(filePath)
 			}

--- a/integration/blackbox.go
+++ b/integration/blackbox.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tedsuo/ifrit/ginkgomon"
 	"github.com/ziutek/syslog"
 
-	"github.com/cloudfoundry/blackbox"
+	"github.com/CrunchyData/blackbox"
 )
 
 type SyslogServer struct {

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -19,7 +19,7 @@ func TestIntegration(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	blackboxPath, err = gexec.Build("github.com/cloudfoundry/blackbox/cmd/blackbox")
+	blackboxPath, err = gexec.Build("github.com/CrunchyData/blackbox/cmd/blackbox")
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/integration/syslog_test.go
+++ b/integration/syslog_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/ginkgomon"
 
-	. "github.com/cloudfoundry/blackbox/integration"
+	. "github.com/CrunchyData/blackbox/integration"
 
 	sl "github.com/ziutek/syslog"
 
-	"github.com/cloudfoundry/blackbox"
-	"github.com/cloudfoundry/blackbox/syslog"
+	"github.com/CrunchyData/blackbox"
+	"github.com/CrunchyData/blackbox/syslog"
 )
 
 var _ = Describe("Blackbox", func() {

--- a/tailer.go
+++ b/tailer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hpcloud/tail"
 	"github.com/hpcloud/tail/watch"
 
-	"github.com/cloudfoundry/blackbox/syslog"
+	"github.com/CrunchyData/blackbox/syslog"
 )
 
 type Tailer struct {


### PR DESCRIPTION
## Overview:
Notes about the change, overall goal of change. Can update after posting PR.

- OpenProject Task ID:
- Related PRs: https://github.com/CrunchyData/syslog-release/pull/1
- Other Related PRs (docs?):

## Added:
- Suffix param

## Removed:
- Any removals are due to the commit difference used in the syslog-release

## Testing Method:
https://github.com/CrunchyData/syslog-release/pull/1